### PR TITLE
Allow dynamic port binding for dashboard (#5)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@v1.1.0
         with:
-          install_local_path_provisioner: true
+          node_image: kindest/node:v1.18.8
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/charts/sorry-cypress/Chart.yaml
+++ b/charts/sorry-cypress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sorry-cypress
 description: A Helm chart for Sorry Cypress
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: 0.6.1
 home: https://sorry-cypress.dev/
 sources:

--- a/charts/sorry-cypress/templates/deployment-dashboard.yml
+++ b/charts/sorry-cypress/templates/deployment-dashboard.yml
@@ -25,15 +25,17 @@ spec:
         - name: CI_URL
           value: {{ .Values.dashboard.environmentVariables.ciUrl | quote }}
         {{- end }}
+        - name: PORT
+          value: "{{ .Values.dashboard.service.port }}"
         image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
         name: {{ include "sorry-cypress-helm.fullname" . }}-dashboard
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.dashboard.service.port }}
         readinessProbe:
           httpGet:
             path: /
-            port: 8080
+            port: {{ .Values.dashboard.service.port }}
           periodSeconds: 10
           timeoutSeconds: 5
           successThreshold: 2


### PR DESCRIPTION
* Allow dynamic port binding for dashboard

* Fix kind k8s version to 1.18

* Further instances where the service port should be set if it's to be properly dynamic

Co-authored-by: tim-sendible <tim@sendible.com>